### PR TITLE
Add emulation of 3rd party device BAE910

### DIFF
--- a/src/BAE910.cpp
+++ b/src/BAE910.cpp
@@ -1,0 +1,109 @@
+#include "BAE910.h"
+
+BAE910::BAE910(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, uint8_t ID6, uint8_t ID7) : OneWireItem(ID1, ID2, ID3, ID4, ID5, ID6, ID7)
+{
+    for (uint8_t i = 0; i < 0x80; ++i)
+        memory.bytes[i] = 0x00;
+}
+
+void BAE910::extCommand(uint8_t ecmd, uint8_t payload_len)
+{
+    // reserved:
+    // 0xBB  Erase Firmware
+    // 0xBA  Flash Firmware
+}
+
+bool BAE910::duty(OneWireHub *hub)
+{
+    uint8_t ta1;
+    uint8_t ta2;
+    uint8_t len;
+    uint8_t ecmd;
+    uint16_t crc = 0;
+
+    uint8_t cmd  = hub->recvAndCRC16(crc);
+
+    switch (cmd)
+    {
+        case 0x11: // READ VERSION
+            crc = hub->sendAndCRC16(BAE910_SW_VER,        crc);
+            crc = hub->sendAndCRC16(BAE910_BOOTSTRAP_VER, crc);
+            // crc
+            crc = ~crc;
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[0]);
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[1]);
+            break;
+
+        case 0x12: // READ TYPE
+            crc = hub->sendAndCRC16(BAE910_DEVICE_TYPE,   crc);
+            crc = hub->sendAndCRC16(BAE910_CHIP_TYPE,     crc);
+            // crc
+            crc = ~crc;
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[0]);
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[1]);
+            break;
+
+        case 0x13: // EXTENDED COMMAND
+            ecmd = hub->recvAndCRC16(crc);
+            len  = hub->recvAndCRC16(crc);
+            if (len > BAE910_SCRATCHPAD_SIZE) {
+                hub->raiseSlaveError(cmd);
+                return false;
+            }
+            for( uint8_t i = 0; i < len; ++i )
+                scratchpad[i] = hub->recvAndCRC16(crc);
+            // crc
+            crc = ~crc;
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[0]);
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[1]);
+            // verify answer from master, then execute command
+            if (hub->recv() == 0xBC)
+                extCommand(ecmd, len);
+            break;
+
+        case 0x14: // READ MEMORY
+            ta1 = hub->recvAndCRC16(crc);
+            ta2 = hub->recvAndCRC16(crc);
+            len = hub->recvAndCRC16(crc);
+            if ((ta1 + len > 0x80) || (ta2 > 0)) {
+                hub->raiseSlaveError(cmd);
+                return false;
+            }
+            // reverse byte order
+            for (uint8_t i = 0; i < len; ++i)
+                crc = hub->sendAndCRC16(memory.bytes[0x7F - ta1 - i], crc);
+            // crc
+            crc = ~crc;
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[0]);
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[1]);
+            break;
+
+        case 0x15: // WRITE MEMORY
+            ta1 = hub->recvAndCRC16(crc);
+            ta2 = hub->recvAndCRC16(crc);
+            len = hub->recvAndCRC16(crc);
+            if ((len > BAE910_SCRATCHPAD_SIZE) || (ta1 + len > 0x80) || (ta2 > 0)) {
+                hub->raiseSlaveError(cmd);
+                return false;
+            }
+            for (uint8_t i = 0; i < len; ++i)
+                scratchpad[i] = hub->recvAndCRC16(crc);
+            // crc
+            crc = ~crc;
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[0]);
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[1]);
+            // verify answer from master, then copy memory
+            if (hub->recv() == 0xBC)
+                // reverse byte order
+                while ( len-- > 0 )
+                    memory.bytes[0x7F - ta1 - len] = scratchpad[len];
+            break;
+
+        case 0x16: // ERASE EEPROM PAGE (not needed/implemented yet)
+        default:
+            hub->raiseSlaveError(cmd);
+            return false;
+    }
+
+    return true;
+}

--- a/src/BAE910.h
+++ b/src/BAE910.h
@@ -1,0 +1,106 @@
+// 0xFC  Multifunction 1-wire slave device @@@
+// works
+
+#ifndef ONEWIRE_BAE910_H
+#define ONEWIRE_BAE910_H
+
+typedef struct
+{
+//  --> reversed fields and write/read in reverse order to achieve swapped byte order
+        uint32_t userp;
+        uint32_t usero;
+        uint32_t usern;
+        uint32_t userm;
+        uint16_t userl;
+        uint16_t userk;
+        uint16_t userj;
+        uint16_t useri;
+        uint8_t  userh;
+        uint8_t  userg;
+        uint8_t  userf;
+        uint8_t  usere;
+        uint8_t  userd;
+        uint8_t  userc;
+        uint8_t  userb;
+        uint8_t  usera;
+        uint16_t maxcps;
+        uint16_t ovruncnt;
+        uint16_t stalledcnt;
+        uint16_t selectcnt;
+        uint16_t resetcnt;
+        uint32_t unused0x52;
+        uint32_t unused0x4e;
+        uint32_t alrt;
+        uint32_t alct;
+        uint16_t alcps;
+        uint16_t alan;
+        uint16_t alap;
+        //
+        uint16_t adc10;
+        uint16_t pc3;
+        uint16_t pc2;
+        uint16_t pc1;
+        uint16_t pc0;
+        uint8_t  unused0x35;
+        uint8_t  alarm;
+        uint8_t  cnt;
+        uint8_t  adc;
+        uint8_t  pio;
+        uint8_t  out;
+        uint32_t count;
+        uint32_t rtc;
+        uint32_t adctotn;
+        uint32_t adctotp;
+        uint16_t cps;
+        uint16_t maxan;
+        uint16_t maxap;
+        uint16_t adcan;
+        uint16_t adcap;
+        uint16_t duty4;
+        uint16_t duty3;
+        uint16_t duty2;
+        uint16_t duty1;
+        uint16_t period2;
+        uint16_t period1;
+        uint8_t  tpm2c;
+        uint8_t  tpm1c;
+        uint8_t  rtcc;
+        uint8_t  alarmc;
+        uint8_t  pioc;
+        uint8_t  outc;
+        uint8_t  cntc;
+        uint8_t  adcc;
+        uint16_t reserved;
+} sBAE910;
+
+typedef union {
+    uint8_t bytes[0x80];
+    sBAE910 field;
+} mBAE910; // overlay with memory_array
+
+
+class BAE910 : public OneWireItem
+{
+private:
+    static constexpr uint8_t  BAE910_DEVICE_TYPE      = 0x02;  // Type 2 for BAE0910. Type 3 for BAE0911 (planned)
+    static constexpr uint8_t  BAE910_CHIP_TYPE        = 0x01;  // Chip type= 0x01 for the MC9S08SH8, 8 pin package soic8
+    static constexpr uint8_t  BAE910_SCRATCHPAD_SIZE  = 32;
+
+protected:
+    uint8_t scratchpad[BAE910_SCRATCHPAD_SIZE];
+    virtual void extCommand(uint8_t ecmd, uint8_t payload_len); // read payload from scratchpad
+
+public:
+    static constexpr uint8_t  BAE910_SW_VER           = 0x01;  // undefined data (0x00 = corrupted)
+    static constexpr uint8_t  BAE910_BOOTSTRAP_VER    = 0x01;  // undefined data
+
+    mBAE910 memory;
+
+    static constexpr uint8_t family_code = 0xFC;
+
+    BAE910(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, uint8_t ID6, uint8_t ID7);
+
+    bool duty(OneWireHub *hub);
+};
+
+#endif


### PR DESCRIPTION
Very flexible client device with 128 bytes of public memory, accessible with OWFS.
No EEPROM or Firmware functions implemented.
